### PR TITLE
Makefile: use php instead of phpdbg for coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
This replaces `phpdbg` with `php` in the coverage target.

Refs: contributte/contributte#73